### PR TITLE
New feature: Get top n columns

### DIFF
--- a/examples/valentine_top_columns_example.py
+++ b/examples/valentine_top_columns_example.py
@@ -1,0 +1,37 @@
+import os
+import pandas as pd
+from valentine import valentine_match
+from valentine.algorithms import SimilarityFlooding
+import pprint
+
+from valentine.metrics.metrics import get_top_n_columns, get_top_n_columns_for_column
+
+
+def main():
+    # Load data using pandas
+    d1_path = os.path.join('data', 'authors1.csv')
+    d2_path = os.path.join('data', 'authors2.csv')
+    df1 = pd.read_csv(d1_path)
+    df2 = pd.read_csv(d2_path)
+
+    # Instantiate matcher and run
+    matcher = SimilarityFlooding()
+    matches = valentine_match(df1, df2, matcher)
+
+    # Find the top-n columns for all columns in dataframe1 (authors1.csv)
+    all_top_2_columns = get_top_n_columns(matches, 2)
+    authors_top_2_columns = get_top_n_columns_for_column(matches, 2, 'Authors')
+
+    pp = pprint.PrettyPrinter(indent=4)
+    print("Found the following matches:")
+    pp.pprint(matches)
+
+    print("Top 2 columns for each column:")
+    pp.pprint(all_top_2_columns)
+
+    print("Top 2 columns for 'Authors' column in table 1:")
+    pp.pprint(authors_top_2_columns)
+
+
+if __name__ == '__main__':
+    main()

--- a/examples/valentine_top_columns_example.py
+++ b/examples/valentine_top_columns_example.py
@@ -20,6 +20,8 @@ def main():
 
     # Find the top-n columns for all columns in dataframe1 (authors1.csv)
     all_top_2_columns = get_top_n_columns(matches, 2)
+
+    # Find the top-n columns for the column 'Authors' in dataframe1
     authors_top_2_columns = get_top_n_columns_for_column(matches, 2, 'Authors')
 
     pp = pprint.PrettyPrinter(indent=4)


### PR DESCRIPTION
Resolves #52 

As stated in issue #52 , it would be useful to be able to get the top n similar columns when analyzing the data. Since the issue is still open, I decided to add this feature myself as I could use it during my data preprocessing

### Solution

This pull request adds two new methods into the metrics.py file

- **get_top_n_columns** which returns a complete dictionary of all top-n columns for each column in the two datasets
- For instance: {('Table1', 'Authors'): ['Authors, 'AccessList']}
- **get_top_n_columns_for_column** Something that could be more useful in my opinion, to return the top columns for a specific dataset
- For instance: What are the top two matches for column 'Access' of table 1?

I am not quite sure what exactly the OP wanted or what the team would prefer to, but at least a boilerplate is established and in case more information should be added that can be easily modified. (e.g. add float value next to it)

### Additional changes

Added a new example to demonstrate the new feature. It uses a different algorithm though as COMA compares the names as well and in this case it might not be much informative

**Notes**

- I didn't find a test case for metrics that's why I didn't add one
- The code style being used complies with PEP-8 

I hope this is useful. Let me know if you prefer any changes or any additional functionality. 