### PR TITLE
Fix for one_to_one_matches incorrect median

### DIFF
--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,8 +1,8 @@
 import unittest
 
 import math
-from valentine.metrics.metrics import get_tp_fn, get_fp, recall, one_to_one_matches, precision
-from copy import deepcopy 
+from valentine.metrics.metrics import one_to_one_matches
+from copy import deepcopy
 
 matches = {
     (('table_1', 'Cited by'), ('table_2', 'Cited by')): 0.8374313,

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,47 @@
+import unittest
+
+import math
+from valentine.metrics.metrics import get_tp_fn, get_fp, recall, one_to_one_matches, precision
+from copy import deepcopy 
+
+matches = {
+    (('table_1', 'Cited by'), ('table_2', 'Cited by')): 0.8374313,
+    (('table_1', 'Authors'), ('table_2', 'Authors')): 0.83498037,
+    (('table_1', 'EID'), ('table_2', 'EID')): 0.8214057,
+}
+
+ground_truth = [
+    ('Cited by', 'Cited by'),
+    ('Authors', 'Authors'),
+    ('EID', 'EID')
+]
+
+
+class TestMetrics(unittest.TestCase):
+
+    def test_one_to_one(self):
+        m = deepcopy(matches)
+
+        # Add multiple matches per column
+        pairs = list(m.keys())
+        for ((ta, ca), (tb, cb)) in pairs:
+            m[((ta, ca), (tb, cb + 'foo'))] = m[((ta, ca), (tb, cb))] / 2
+
+        # Verify that len gets corrected to 3
+        m_one_to_one = one_to_one_matches(m)
+        assert len(m_one_to_one) == 3 and len(m) == 6
+
+        # Verify that none of the lower similarity "foo" entries made it
+        for ((ta, ca), (tb, cb)) in pairs:
+            assert ((ta, ca), (tb, cb + 'foo')) not in m_one_to_one
+
+        # Add one new entry with lower similarity
+        m_entry = deepcopy(matches)
+        m_entry[(('table_1', 'BLA'), ('table_2', 'BLA'))] = 0.7214057
+
+        m_entry_one_to_one = one_to_one_matches(m_entry)
+
+        # Verify that all remaining values are above the median
+        median = sorted(set(m_entry.values()))[math.ceil(len(m_entry)/2)]
+        for k in m_entry_one_to_one:
+            assert m_entry_one_to_one[k] >= median

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -42,6 +42,6 @@ class TestMetrics(unittest.TestCase):
         m_entry_one_to_one = one_to_one_matches(m_entry)
 
         # Verify that all remaining values are above the median
-        median = sorted(set(m_entry.values()))[math.ceil(len(m_entry)/2)]
+        median = sorted(set(m_entry.values()), reverse=True)[math.ceil(len(m_entry)/2)]
         for k in m_entry_one_to_one:
             assert m_entry_one_to_one[k] >= median

--- a/valentine/metrics/metrics.py
+++ b/valentine/metrics/metrics.py
@@ -28,7 +28,7 @@ def one_to_one_matches(matches: dict):
         matched[key[0]] = False
         matched[key[1]] = False
 
-    median = sorted(set_match_values)[math.ceil(len(set_match_values)/2)]
+    median = sorted(set_match_values, reverse=True)[math.ceil(len(set_match_values)/2)]
 
     matches1to1 = dict()
 

--- a/valentine/metrics/metrics.py
+++ b/valentine/metrics/metrics.py
@@ -28,7 +28,7 @@ def one_to_one_matches(matches: dict):
         matched[key[0]] = False
         matched[key[1]] = False
 
-    median = list(set_match_values)[math.ceil(len(set_match_values)/2)]
+    median = sorted(set_match_values)[math.ceil(len(set_match_values)/2)]
 
     matches1to1 = dict()
 


### PR DESCRIPTION
The `one_to_one_matches` method in the `metrics` module removes matches based on discarding similarities below the median, however the conversion of the similarities to a set breaks the sort order, which causes incorrect sampling of the median.

I fixed this by changed `list` into `sorted`, which ensures that we take the median from a sorted list. Also added the `reverse` keyword since we assume in the documentation that `matches` is sorted in a descending order.

In addition, a test case was added for `one_to_one_matches`, that tests this and some other expected behaviour.