### PR TITLE
Allign Cupid closer to the original paper

### DIFF
--- a/tests/test_algorithms.py
+++ b/tests/test_algorithms.py
@@ -1,3 +1,5 @@
+import numpy as np
+import pandas as pd
 import pytest
 
 from tests import df1, df2
@@ -40,6 +42,287 @@ def test_cupid():
     matches_cu_matcher = cu_matcher.get_matches(d1, d2)
     # Check that it actually produced output
     assert len(matches_cu_matcher) > 0
+
+
+def test_cupid_paper_figure7():
+    """Test based on Figure 7 from the Cupid paper (Madhavan et al. 2001).
+
+    Two purchase order schemas (CIDX and Excel) with columns that have similar
+    but not identical names. Verifies that Cupid's linguistic + structural
+    matching correctly identifies correspondences across naming variations.
+    """
+    rng = np.random.default_rng(42)
+    n = 5
+
+    # CIDX Purchase Order schema (leaf elements from Figure 7)
+    cidx_df = pd.DataFrame(
+        {
+            "PONumber": rng.integers(1000, 9999, n),
+            "PODate": pd.date_range("2024-01-01", periods=n),
+            "ContactName": [f"Name{i}" for i in range(n)],
+            "ContactEmail": [f"email{i}@example.com" for i in range(n)],
+            "ContactPhone": [f"555-000{i}" for i in range(n)],
+            "Street1": [f"{i} Main St" for i in range(n)],
+            "City": [f"City{i}" for i in range(n)],
+            "StateProvince": [f"State{i}" for i in range(n)],
+            "PostalCode": rng.integers(10000, 99999, n),
+            "Country": [f"Country{i}" for i in range(n)],
+            "unitPrice": rng.random(n) * 100,
+            "qty": rng.integers(1, 100, n),
+            "partno": rng.integers(100, 999, n),
+        }
+    )
+
+    # Excel Purchase Order schema (leaf elements from Figure 7)
+    excel_df = pd.DataFrame(
+        {
+            "orderNum": rng.integers(1000, 9999, n),
+            "orderDate": pd.date_range("2024-01-01", periods=n),
+            "contactName": [f"Name{i}" for i in range(n)],
+            "companyName": [f"Company{i}" for i in range(n)],
+            "telephone": [f"555-000{i}" for i in range(n)],
+            "street1": [f"{i} Main St" for i in range(n)],
+            "city": [f"City{i}" for i in range(n)],
+            "stateProvince": [f"State{i}" for i in range(n)],
+            "postalCode": rng.integers(10000, 99999, n),
+            "country": [f"Country{i}" for i in range(n)],
+            "unitPrice": rng.random(n) * 100,
+            "Quantity": rng.integers(1, 100, n),
+            "partNumber": rng.integers(100, 999, n),
+        }
+    )
+
+    cidx_table = DataframeTable(cidx_df, name="CIDX_PO")
+    excel_table = DataframeTable(excel_df, name="Excel_PO")
+
+    matcher = Cupid()
+    matches = matcher.get_matches(cidx_table, excel_table)
+
+    assert len(matches) > 0
+
+    # Extract matched column name pairs for easier assertion
+    matched_pairs = {}
+    for ((_t1, col1), (_t2, col2)), score in matches.items():
+        matched_pairs[(col1, col2)] = score
+
+    # Columns with identical or near-identical names should be matched
+    # (case-insensitive matches that Cupid's linguistic matching handles)
+    expected_matches = [
+        ("unitPrice", "unitPrice"),
+        ("City", "city"),
+        ("StateProvince", "stateProvince"),
+        ("PostalCode", "postalCode"),
+        ("Country", "country"),
+        ("ContactName", "contactName"),
+        ("Street1", "street1"),
+    ]
+
+    for col1, col2 in expected_matches:
+        assert (col1, col2) in matched_pairs or (col2, col1) in matched_pairs, (
+            f"Expected match ({col1}, {col2}) not found in results. "
+            f"Matched pairs: {list(matched_pairs.keys())}"
+        )
+
+
+def _cupid_matched_pairs(source_table, target_table):
+    """Run Cupid and return {(col1, col2): score} dict."""
+    matcher = Cupid()
+    matches = matcher.get_matches(source_table, target_table)
+    pairs = {}
+    for ((_t1, col1), (_t2, col2)), score in matches.items():
+        pairs[(col1, col2)] = score
+    return pairs
+
+
+def _assert_match_found(matched_pairs, col1, col2):
+    assert (col1, col2) in matched_pairs or (col2, col1) in matched_pairs, (
+        f"Expected match ({col1}, {col2}) not found. Matched pairs: {list(matched_pairs.keys())}"
+    )
+
+
+def test_cupid_paper_figure8_products():
+    """Figure 8: RDB Products vs Star Products.
+
+    Both schemas have a Products table with nearly identical columns:
+    ProductID, ProductName, BrandID, BrandDescription.
+    """
+    rng = np.random.default_rng(42)
+    n = 5
+
+    # RDB Schema PRODUCTS table
+    rdb_products = pd.DataFrame(
+        {
+            "ProductID": rng.integers(1, 1000, n),
+            "BrandID": rng.integers(1, 50, n),
+            "ProductName": [f"Product{i}" for i in range(n)],
+            "BrandDescription": [f"Brand{i}" for i in range(n)],
+        }
+    )
+
+    # Star Schema PRODUCTS table
+    star_products = pd.DataFrame(
+        {
+            "ProductID": rng.integers(1, 1000, n),
+            "ProductName": [f"Product{i}" for i in range(n)],
+            "BrandID": rng.integers(1, 50, n),
+            "BrandDescription": [f"Brand{i}" for i in range(n)],
+        }
+    )
+
+    matched = _cupid_matched_pairs(
+        DataframeTable(rdb_products, name="RDB_Products"),
+        DataframeTable(star_products, name="Star_Products"),
+    )
+
+    assert len(matched) > 0
+    for col in ["ProductID", "ProductName", "BrandID", "BrandDescription"]:
+        _assert_match_found(matched, col, col)
+
+
+def test_cupid_paper_figure8_customers():
+    """Figure 8: RDB Customers vs Star Customers.
+
+    The RDB table uses CompanyName, ContactFirstName, ContactLastName,
+    StateOrProvince while the Star table uses CustomerName, PostalCode,
+    CustomerTypeID, CustomerTypeDescription, State. Cupid should match
+    columns with identical names (CustomerID, PostalCode) and similar
+    names (StateOrProvince vs State).
+    """
+    rng = np.random.default_rng(42)
+    n = 5
+
+    # RDB Schema CUSTOMERS table
+    rdb_customers = pd.DataFrame(
+        {
+            "CustomerID": rng.integers(1, 1000, n),
+            "CompanyName": [f"Company{i}" for i in range(n)],
+            "ContactFirstName": [f"First{i}" for i in range(n)],
+            "ContactLastName": [f"Last{i}" for i in range(n)],
+            "BillingAddress": [f"{i} Elm St" for i in range(n)],
+            "City": [f"City{i}" for i in range(n)],
+            "StateOrProvince": [f"State{i}" for i in range(n)],
+            "PostalCode": rng.integers(10000, 99999, n),
+            "Country": [f"Country{i}" for i in range(n)],
+            "PhoneNumber": [f"555-{i:04d}" for i in range(n)],
+        }
+    )
+
+    # Star Schema CUSTOMERS table
+    star_customers = pd.DataFrame(
+        {
+            "CustomerID": rng.integers(1, 1000, n),
+            "CustomerName": [f"Customer{i}" for i in range(n)],
+            "CustomerTypeID": rng.integers(1, 10, n),
+            "CustomerTypeDescription": [f"Type{i}" for i in range(n)],
+            "PostalCode": rng.integers(10000, 99999, n),
+            "State": [f"State{i}" for i in range(n)],
+        }
+    )
+
+    matched = _cupid_matched_pairs(
+        DataframeTable(rdb_customers, name="RDB_Customers"),
+        DataframeTable(star_customers, name="Star_Customers"),
+    )
+
+    assert len(matched) > 0
+    _assert_match_found(matched, "CustomerID", "CustomerID")
+    _assert_match_found(matched, "PostalCode", "PostalCode")
+
+
+def test_cupid_paper_figure8_orders_sales():
+    """Figure 8: RDB Orders/OrderDetails vs Star Sales.
+
+    The paper notes Cupid matches the join of Orders and OrderDetails to Sales.
+    Since Valentine handles flat tables, we represent the RDB side as a
+    denormalized Orders table and match against the Star Sales table.
+    Shared columns: OrderID, OrderDetailID, CustomerID, ProductID, OrderDate,
+    Quantity, UnitPrice, Discount.
+    """
+    rng = np.random.default_rng(42)
+    n = 5
+
+    # RDB Schema: denormalized ORDERS + ORDERDETAILS
+    rdb_orders = pd.DataFrame(
+        {
+            "OrderID": rng.integers(1, 10000, n),
+            "OrderDetailID": rng.integers(1, 50000, n),
+            "CustomerID": rng.integers(1, 1000, n),
+            "ProductID": rng.integers(1, 500, n),
+            "OrderDate": pd.date_range("2024-01-01", periods=n),
+            "Quantity": rng.integers(1, 100, n),
+            "UnitPrice": rng.random(n) * 100,
+            "Discount": rng.random(n) * 0.5,
+            "ShipName": [f"Ship{i}" for i in range(n)],
+            "ShipAddress": [f"{i} Oak Ave" for i in range(n)],
+            "FreightCharge": rng.random(n) * 50,
+        }
+    )
+
+    # Star Schema: SALES fact table
+    star_sales = pd.DataFrame(
+        {
+            "OrderID": rng.integers(1, 10000, n),
+            "OrderDetailID": rng.integers(1, 50000, n),
+            "CustomerID": rng.integers(1, 1000, n),
+            "PostalCode": rng.integers(10000, 99999, n),
+            "ProductID": rng.integers(1, 500, n),
+            "OrderDate": pd.date_range("2024-01-01", periods=n),
+            "Quantity": rng.integers(1, 100, n),
+            "UnitPrice": rng.random(n) * 100,
+            "Discount": rng.random(n) * 0.5,
+        }
+    )
+
+    matched = _cupid_matched_pairs(
+        DataframeTable(rdb_orders, name="RDB_Orders"),
+        DataframeTable(star_sales, name="Star_Sales"),
+    )
+
+    assert len(matched) > 0
+    for col in ["OrderID", "OrderDetailID", "CustomerID", "ProductID", "Quantity", "UnitPrice"]:
+        _assert_match_found(matched, col, col)
+
+
+def test_cupid_paper_figure8_geography():
+    """Figure 8: RDB Territories/Region vs Star Geography.
+
+    The paper notes the Geography table columns map to Region and Territory
+    columns. Shared concepts: TerritoryID, TerritoryDescription, RegionID,
+    RegionDescription, PostalCode.
+    """
+    rng = np.random.default_rng(42)
+    n = 5
+
+    # RDB Schema: denormalized TERRITORIES + REGION
+    rdb_territories = pd.DataFrame(
+        {
+            "TerritoryID": rng.integers(1, 100, n),
+            "TerritoryDescription": [f"Territory{i}" for i in range(n)],
+            "RegionID": rng.integers(1, 10, n),
+            "RegionDescription": [f"Region{i}" for i in range(n)],
+        }
+    )
+
+    # Star Schema: GEOGRAPHY dimension table
+    star_geography = pd.DataFrame(
+        {
+            "PostalCode": rng.integers(10000, 99999, n),
+            "CustomerName": [f"Customer{i}" for i in range(n)],
+            "TerritoryDescription": [f"Territory{i}" for i in range(n)],
+            "TerritoryID": rng.integers(1, 100, n),
+            "RegionID": rng.integers(1, 10, n),
+            "RegionDescription": [f"Region{i}" for i in range(n)],
+        }
+    )
+
+    matched = _cupid_matched_pairs(
+        DataframeTable(rdb_territories, name="RDB_Territories"),
+        DataframeTable(star_geography, name="Star_Geography"),
+    )
+
+    assert len(matched) > 0
+    for col in ["TerritoryID", "TerritoryDescription", "RegionID", "RegionDescription"]:
+        _assert_match_found(matched, col, col)
 
 
 def test_distribution_based():

--- a/tests/test_cupid_algo.py
+++ b/tests/test_cupid_algo.py
@@ -219,7 +219,9 @@ class TestCupidLinguisticStructural(unittest.TestCase):
         self.assertGreaterEqual(ssim, 0.0)
         self.assertLessEqual(ssim, 1.0)
 
-        cupid_struct.change_structural_similarity(leaves_s, leaves_t, sims, factor=2.0)
+        cupid_struct.change_structural_similarity(
+            leaves_s, leaves_t, sims, factor=2.0, leaf_w_struct=0.5
+        )
         self.assertEqual(sims[(leaves_s[0], leaves_t[0])]["ssim"], 1.0)
 
     def test_tree_match_helpers_and_mapping(self):

--- a/valentine/algorithms/cupid/linguistic_matching.py
+++ b/valentine/algorithms/cupid/linguistic_matching.py
@@ -145,8 +145,8 @@ def l_sim_proc(pair: tuple, compatibility_table: dict):
 
 
 def data_type_similarity(token_set1, token_set2):
-    sum1 = 0
-    sum2 = 0
+    numerator = 0
+    denominator = 0
     for tt in TokenTypes:
         if tt == TokenTypes.SYMBOLS:
             continue
@@ -154,12 +154,12 @@ def data_type_similarity(token_set1, token_set2):
         t2 = [t for t in token_set2 if t.token_type == tt]
         if len(t1) == 0 or len(t2) == 0:
             continue
-        sim = name_similarity_tokens(t1, t2)
-        sum1 = sum1 + tt.weight * sim
-        sum2 = sum2 + tt.weight
-    if sum1 == 0 or sum2 == 0:
+        raw_sum = get_partial_similarity(t1, t2) + get_partial_similarity(t2, t1)
+        numerator += tt.weight * raw_sum
+        denominator += tt.weight * (len(t1) + len(t2))
+    if denominator == 0:
         return 0
-    return sum1 / sum2
+    return numerator / denominator
 
 
 # max is 1
@@ -220,8 +220,8 @@ def compute_similarity_leven(word1, word2):
 
 # max is 0.5
 def name_similarity_elements(element1, element2):
-    sum1 = 0
-    sum2 = 0
+    numerator = 0
+    denominator = 0
 
     for tt in TokenTypes:
         if tt == TokenTypes.SYMBOLS:
@@ -230,14 +230,14 @@ def name_similarity_elements(element1, element2):
         t2 = element2.get_tokens_by_token_type(tt)
         if len(t1) == 0 or len(t2) == 0:
             continue
-        sim = name_similarity_tokens(t1, t2)
-        sum1 = sum1 + tt.weight * sim
-        sum2 = sum2 + tt.weight
+        raw_sum = get_partial_similarity(t1, t2) + get_partial_similarity(t2, t1)
+        numerator += tt.weight * raw_sum
+        denominator += tt.weight * (len(t1) + len(t2))
 
-    if sum1 == 0 or sum2 == 0:
+    if denominator == 0:
         return 0
 
-    return sum1 / sum2
+    return numerator / denominator
 
 
 def compute_lsim(element1, element2):

--- a/valentine/algorithms/cupid/structural_similarity.py
+++ b/valentine/algorithms/cupid/structural_similarity.py
@@ -25,10 +25,13 @@ def compute_ssim(node_s, node_t, sims, th_accept=0.5):
     return (len(s_strong_link) + len(t_strong_link)) / (len(s_leaves) + len(t_leaves))
 
 
-def change_structural_similarity(leaves_s, leaves_t, sims, factor):
+def change_structural_similarity(leaves_s, leaves_t, sims, factor, leaf_w_struct):
     all_leaves = product(leaves_s, leaves_t)
 
     for pair in all_leaves:
         if pair in sims:
             partial = sims[pair]["ssim"] * factor
             sims[pair]["ssim"] = partial if partial < 1 else 1
+            sims[pair]["wsim"] = (
+                leaf_w_struct * sims[pair]["ssim"] + (1 - leaf_w_struct) * sims[pair]["lsim"]
+            )

--- a/valentine/algorithms/cupid/tree_match.py
+++ b/valentine/algorithms/cupid/tree_match.py
@@ -5,7 +5,6 @@ from anytree import LevelOrderIter, PostOrderIter
 
 from ..match import Match
 from .linguistic_matching import comparison, compute_compatibility, compute_lsim
-from .schema_element import SchemaElement
 from .structural_similarity import change_structural_similarity, compute_ssim
 
 
@@ -17,7 +16,7 @@ def get_sims(s_leaves, t_leaves, compatibility_table, l_sims, leaf_w_struct):
     sims = {}
     for s, t in product(s_leaves, t_leaves):
         if s.data_type in compatibility_table and t.data_type in compatibility_table:
-            s_sim = compatibility_table[s.data_type][t.data_type]
+            s_sim = compatibility_table[s.data_type][t.data_type] * 0.5
             w_sim = compute_weighted_similarity(
                 s_sim, l_sims.get((s.long_name, t.long_name), 0), leaf_w_struct
             )
@@ -53,34 +52,30 @@ def tree_match(
     for s in s_post_order:
         s_name = s.long_name
 
-        if isinstance(s, SchemaElement):
+        if s.is_leaf:
             continue
 
         for t in t_post_order:
             t_name = t.long_name
 
-            if isinstance(t, SchemaElement):
+            if t.is_leaf:
                 continue
 
-            # if the nodes are on the same level
-            if s.height == t.height:
-                ssim = compute_ssim(s, t, sims, th_accept)
+            ssim = compute_ssim(s, t, sims, th_accept)
 
-                # the nodes should have a similar number of leaves (within a factor of 2)
-                if math.isnan(ssim):
-                    continue
+            # the nodes should have a similar number of leaves (within a factor of 2)
+            if math.isnan(ssim):
+                continue
 
-                if (s.long_name, t.long_name) not in l_sims:
-                    l_sims[(s.long_name, t.long_name)] = 0
+            if (s.long_name, t.long_name) not in l_sims:
+                l_sims[(s.long_name, t.long_name)] = 0
 
-                wsim = compute_weighted_similarity(
-                    ssim, l_sims[(s.long_name, t.long_name)], w_struct
-                )
-                sims[(s_name, t_name)] = {
-                    "ssim": ssim,
-                    "lsim": l_sims[(s.long_name, t.long_name)],
-                    "wsim": wsim,
-                }
+            wsim = compute_weighted_similarity(ssim, l_sims[(s.long_name, t.long_name)], w_struct)
+            sims[(s_name, t_name)] = {
+                "ssim": ssim,
+                "lsim": l_sims[(s.long_name, t.long_name)],
+                "wsim": wsim,
+            }
 
             if (s_name, t_name) in sims and sims[(s_name, t_name)]["wsim"] > th_high:
                 change_structural_similarity(
@@ -88,6 +83,7 @@ def tree_match(
                     [n.long_name for n in t.leaves],
                     sims,
                     c_inc,
+                    leaf_w_struct,
                 )
 
             if (s_name, t_name) in sims and sims[(s_name, t_name)]["wsim"] < th_low:
@@ -96,6 +92,7 @@ def tree_match(
                     [n.long_name for n in t.leaves],
                     sims,
                     c_dec,
+                    leaf_w_struct,
                 )
     return sims
 
@@ -107,29 +104,27 @@ def recompute_wsim(source_tree, target_tree, sims, w_struct=0.6, th_accept=0.14)
     for s in s_post_order:
         s_name = s.long_name
 
-        if isinstance(s, SchemaElement):
+        if s.is_leaf:
             continue
 
         for t in t_post_order:
             t_name = t.long_name
 
-            if isinstance(t, SchemaElement):
+            if t.is_leaf:
                 continue
 
-            # if the nodes are on the same level and are not leaves
-            if s.height == t.height and (s.height > 0 and t.height > 0):
-                ssim = compute_ssim(s, t, sims, th_accept)
+            ssim = compute_ssim(s, t, sims, th_accept)
 
-                if math.isnan(ssim):
-                    continue
+            if math.isnan(ssim):
+                continue
 
-                if (s_name, t_name) not in sims:
-                    lsim = compute_lsim(s.name, t.name)
-                else:
-                    lsim = sims[(s_name, t_name)]["lsim"]
+            if (s_name, t_name) not in sims:
+                lsim = compute_lsim(s, t)
+            else:
+                lsim = sims[(s_name, t_name)]["lsim"]
 
-                wsim = compute_weighted_similarity(ssim, lsim, w_struct)
-                sims[(s_name, t_name)] = {"ssim": ssim, "lsim": lsim, "wsim": wsim}
+            wsim = compute_weighted_similarity(ssim, lsim, w_struct)
+            sims[(s_name, t_name)] = {"ssim": ssim, "lsim": lsim, "wsim": wsim}
     return sims
 
 


### PR DESCRIPTION
### Bugs fixed

- **Structural matching:** `isinstance(s, SchemaElement)` was always `True` because `SchemaElementNode` inherits from `SchemaElement`, causing every node to be skipped in the post-order loop. Fixed by checking `s.is_leaf` instead, so only leaf nodes are skipped and table/root nodes get their structural similarity computed.

- **Leaf ssim range [0, 1] instead of [0, 0.5]:** The paper specifies that data type compatibility for leaves must be in [0, 0.5] so structural matching can increase it. Scaled by `* 0.5` in `get_sims()`.

- **`name_similarity_elements` formula incorrect:** The paper's formula (Section 5.3) puts the raw similarity sums in the numerator and token set sizes in the denominator: `ns(m1,m2) = Σ(w_i × raw_sum_i) / Σ(w_i × (|T_{1i}| + |T_{2i}|))`. The code was instead computing a simple weighted mean of already-normalized values. Fixed both `name_similarity_elements()` and `data_type_similarity()`.

- **Leaf wsim not updated after ssim changes:** When `change_structural_similarity` modifies leaf ssim via `c_inc`/`c_dec`, the corresponding wsim was not recomputed, leaving stale values for stronglink detection. Now recomputes `wsim = w_struct * ssim + (1 - w_struct) * lsim` after each ssim update.

- **Unnecessary height check removed:** The paper's TreeMatch (Figure 3) has no height constraint on non-leaf comparisons. Removed `if s.height == t.height`.

- **`recompute_wsim` passing strings to `compute_lsim`:** Exposed by the `is_leaf` fix — now passes node objects which have the required `get_tokens_by_token_type` and `categories` attributes.

### Tests added

Added integration tests based on examples from the paper:
- **Figure 7** — CIDX vs Excel purchase order schemas with naming variations (case differences, abbreviations)
- **Figure 8** — RDB vs Star schema matching across 4 table pairs (Products, Customers, Orders/Sales, Territories/Geography)